### PR TITLE
Improve CMake install targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,3 +43,4 @@ include(GNUInstallDirs)
 
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/zarchive/ DESTINATION "include/zarchive" FILES_MATCHING PATTERN "zarchive*.h")
 INSTALL(TARGETS zarchive LIBRARY)
+INSTALL(TARGETS zarchiveTool)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,4 +42,4 @@ target_link_libraries(zarchiveTool PRIVATE zarchive)
 include(GNUInstallDirs)
 
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/zarchive/ DESTINATION "include/zarchive" FILES_MATCHING PATTERN "zarchive*.h")
-INSTALL(TARGETS zarchive DESTINATION lib)
+INSTALL(TARGETS zarchive LIBRARY)


### PR DESCRIPTION
I was writing a rpm for openSUSE Tumbleweed and I found two problems:
* The zarchive executable wasn't being installed
* The library was being installed to /usr/lib instead of /usr/lib64. By using `INSTALL(TARGETS zarchive LIBRARY)` cmake should handle it.