### PR TITLE
Fix build on macOS with clang 11

### DIFF
--- a/src/zarchivereader.cpp
+++ b/src/zarchivereader.cpp
@@ -235,7 +235,7 @@ uint64_t ZArchiveReader::ReadFromFile(ZArchiveNodeHandle nodeHandle, uint64_t of
 	{
 		uint64_t blockIdx = rawReadOffset / _ZARCHIVE::COMPRESSED_BLOCK_SIZE;
 		uint32_t blockOffset = (uint32_t)(rawReadOffset % _ZARCHIVE::COMPRESSED_BLOCK_SIZE);
-		uint32_t stepSize = std::min(remainingBytes, _ZARCHIVE::COMPRESSED_BLOCK_SIZE - blockOffset);
+		uint32_t stepSize = std::min<uint32_t>(remainingBytes, _ZARCHIVE::COMPRESSED_BLOCK_SIZE - blockOffset);
 		CacheBlock* block = GetCachedBlock(blockIdx);
 		if (!block)
 			return 0;


### PR DESCRIPTION
This should fix build on macOS with clang 11:

```
cmake: enabled parallel building
building
build flags: -j10 -l10 SHELL=/nix/store/cmcl1jichs33ynwv5apzs8r8ndx2w2pi-bash-5.1-p16/bin/bash
[ 50%] Building CXX object CMakeFiles/zarchive.dir/src/zarchivereader.cpp.o
[ 50%] Building CXX object CMakeFiles/zarchive.dir/src/zarchivewriter.cpp.o
[ 50%] Building C object CMakeFiles/zarchive.dir/src/sha_256.c.o
/tmp/nix-build-zarchive-0.1.1.drv-0/source/src/zarchivereader.cpp:238:23: error: no matching function for call to 'min'
                uint32_t stepSize = std::min(remainingBytes, _ZARCHIVE::COMPRESSED_BLOCK_SIZE - blockOffset);
                                    ^~~~~~~~
/nix/store/1r3mrri4afdhshaibaamb3rafvy4ngv9-libcxx-11.1.0-dev/include/c++/v1/algorithm:2560:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('unsigned long long' vs. 'unsigned long')
min(const _Tp& __a, const _Tp& __b)
^
/nix/store/1r3mrri4afdhshaibaamb3rafvy4ngv9-libcxx-11.1.0-dev/include/c++/v1/algorithm:2571:1: note: candidate template ignored: could not match 'initializer_list<type-parameter-0-0>' against 'unsigned long long'
min(initializer_list<_Tp> __t, _Compare __comp)
^
/nix/store/1r3mrri4afdhshaibaamb3rafvy4ngv9-libcxx-11.1.0-dev/include/c++/v1/algorithm:2580:1: note: candidate function template not viable: requires single argument '__t', but 2 arguments were provided
min(initializer_list<_Tp> __t)
^
/nix/store/1r3mrri4afdhshaibaamb3rafvy4ngv9-libcxx-11.1.0-dev/include/c++/v1/algorithm:2551:1: note: candidate function template not viable: requires 3 arguments, but 2 were provided
min(const _Tp& __a, const _Tp& __b, _Compare __comp)
^
1 error generated.
make[2]: *** [CMakeFiles/zarchive.dir/build.make:90: CMakeFiles/zarchive.dir/src/zarchivereader.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:85: CMakeFiles/zarchive.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```