### PR TITLE
build: general improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,3 +49,14 @@ target_link_libraries(zarchiveTool PRIVATE zarchive)
 install(DIRECTORY include/zarchive/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/zarchive" FILES_MATCHING PATTERN "zarchive*.h")
 install(TARGETS zarchive)
 install(TARGETS zarchiveTool)
+
+# pkg-config
+include(JoinPaths) # can be replaced by cmake_path(APPEND) in CMake 3.20
+join_paths(PKGCONFIG_INCLUDEDIR "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
+join_paths(PKGCONFIG_LIBDIR "\${prefix}" "${CMAKE_INSTALL_LIBDIR}")
+
+configure_file("zarchive.pc.in" "zarchive.pc" @ONLY)
+install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/zarchive.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,36 +1,43 @@
 ﻿cmake_minimum_required (VERSION 3.15)
 
-set(CMAKE_CXX_STANDARD 20)
+if (WIN32)
+    set(VCPKG_TARGET_TRIPLET "x64-windows-static" CACHE STRING "VCPKG Target Triplet to use")
+endif()
 
-cmake_policy(SET CMP0091 NEW) # for MSVC_RUNTIME_LIBRARY
+project("ZArchive"
+    VERSION "0.1.1"
+    DESCRIPTION "Library for creating and reading zstd-compressed file archives"
+    HOMEPAGE_URL "https://github.com/Exzap/ZArchive"
+)
 
-set(VCPKG_TARGET_TRIPLET "x64-windows-static" CACHE STRING "VCPKG Target Triplet to use")
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
-project ("ZArchive")
+include(GNUInstallDirs)
 
 set(SOURCE_FILES_LIB
-src/zarchivewriter.cpp
-src/zarchivereader.cpp
-src/sha_256.c
+    src/zarchivewriter.cpp
+    src/zarchivereader.cpp
+    src/sha_256.c
 )
 
 # build static library
-add_library (zarchive STATIC ${SOURCE_FILES_LIB})
-set_property(TARGET zarchive PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+add_library (zarchive ${SOURCE_FILES_LIB})
+add_library (ZArchive::zarchive ALIAS zarchive)
+target_compile_features(zarchive PUBLIC cxx_std_20)
+set_target_properties(zarchive PROPERTIES
+    MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
+    VERSION "${PROJECT_VERSION}"
+    SOVERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"
+)
 
 target_include_directories(zarchive
     PUBLIC
-        $<INSTALL_INTERFACE:include>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-)
-
-
-include_directories(PRIVATE
-${CMAKE_CURRENT_SOURCE_DIR}/include
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
 )
 
 find_package(zstd REQUIRED)
-target_link_libraries(zarchive PRIVATE zstd::libzstd_static)
+target_link_libraries(zarchive PRIVATE zstd::zstd)
 
 # standalone executable
 add_executable (zarchiveTool src/main.cpp)
@@ -39,8 +46,6 @@ set_target_properties(zarchiveTool PROPERTIES OUTPUT_NAME "zarchive")
 target_link_libraries(zarchiveTool PRIVATE zarchive)
 
 # install
-include(GNUInstallDirs)
-
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/zarchive/ DESTINATION "include/zarchive" FILES_MATCHING PATTERN "zarchive*.h")
-INSTALL(TARGETS zarchive LIBRARY)
-INSTALL(TARGETS zarchiveTool)
+install(DIRECTORY include/zarchive/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/zarchive" FILES_MATCHING PATTERN "zarchive*.h")
+install(TARGETS zarchive)
+install(TARGETS zarchiveTool)

--- a/cmake/Findzstd.cmake
+++ b/cmake/Findzstd.cmake
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2022 Andrea Pappacoda <andrea@pappacoda.it>
+# SPDX-License-Identifier: ISC
+
+include(FindPackageHandleStandardArgs)
+
+find_package(zstd CONFIG QUIET)
+if (zstd_FOUND)
+	# Use upstream zstdConfig.cmake if possible
+	if (NOT TARGET zstd::zstd)
+		if (TARGET zstd::libzstd_static)
+			add_library(zstd::zstd ALIAS zstd::libzstd_static)
+		elseif (TARGET zstd::libzstd_shared)
+			add_library(zstd::zstd ALIAS zstd::libzstd_shared)
+		endif()
+	endif()
+	find_package_handle_standard_args(zstd CONFIG_MODE)
+else()
+	# Fallback to pkg-config otherwise
+	find_package(PkgConfig)
+	if (PKG_CONFIG_FOUND)
+		pkg_search_module(libzstd IMPORTED_TARGET GLOBAL libzstd)
+		if (libzstd_FOUND)
+			add_library(zstd::zstd ALIAS PkgConfig::libzstd)
+		endif()
+	endif()
+
+	find_package_handle_standard_args(zstd
+		REQUIRED_VARS
+			libzstd_LINK_LIBRARIES
+			libzstd_FOUND
+		VERSION_VAR libzstd_VERSION
+	)
+endif()

--- a/cmake/JoinPaths.cmake
+++ b/cmake/JoinPaths.cmake
@@ -1,0 +1,23 @@
+# This module provides function for joining paths
+# known from most languages
+#
+# SPDX-License-Identifier: (MIT OR CC0-1.0)
+# Copyright 2020 Jan Tojnar
+# https://github.com/jtojnar/cmake-snips
+#
+# Modelled after Python’s os.path.join
+# https://docs.python.org/3.7/library/os.path.html#os.path.join
+# Windows not supported
+function(join_paths joined_path first_path_segment)
+    set(temp_path "${first_path_segment}")
+    foreach(current_segment IN LISTS ARGN)
+        if(NOT ("${current_segment}" STREQUAL ""))
+            if(IS_ABSOLUTE "${current_segment}")
+                set(temp_path "${current_segment}")
+            else()
+                set(temp_path "${temp_path}/${current_segment}")
+            endif()
+        endif()
+    endforeach()
+    set(${joined_path} "${temp_path}" PARENT_SCOPE)
+endfunction()

--- a/zarchive.pc.in
+++ b/zarchive.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=@PKGCONFIG_INCLUDEDIR@
+libdir=@PKGCONFIG_LIBDIR@
+
+Name: @PROJECT_NAME@
+Description: @PROJECT_DESCRIPTION@
+URL: @PROJECT_HOMEPAGE_URL@
+Version: @PROJECT_VERSION@
+Requires.private: libzstd
+Libs: -L${libdir} -lzarchive
+Cflags: -I${includedir}


### PR DESCRIPTION
This patch contains several small changes to the CMake build script:

- Set the C++ standard version with a target feature instead of by modifying the global `CMAKE_CXX_STANDARD`, so that integration as a subproject doesn't create issues.
- Drop explicit `CMP0091=NEW`, as that is already done by setting the `cmake_minimum_required` to version 3.15.
- Permit building the library as a shared one, and also give it a version and a soversion; here I supposed ABI compatibility between releases with the same major.minor version.
- Add a `Findzstd.cmake` module that looks for libzstd using pkg-config if the Config file is not available (like in most Linux distros).
- Use values from `GNUInstallDirs` instead of hardcoded ones.
- Support pkg-config by generating a .pc file.

It would be nice to know what your ABI compatibility guarantees are, as my supposition could be wrong.