### PR TITLE
docs: add a manual page

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(zarchiveTool PRIVATE zarchive)
 install(DIRECTORY include/zarchive/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/zarchive" FILES_MATCHING PATTERN "zarchive*.h")
 install(TARGETS zarchive)
 install(TARGETS zarchiveTool)
+install(FILES "zarchive.1" TYPE MAN)
 
 # pkg-config
 include(JoinPaths) # can be replaced by cmake_path(APPEND) in CMake 3.20

--- a/zarchive.1
+++ b/zarchive.1
@@ -1,0 +1,46 @@
+.\" SPDX-FileCopyrightText: 2022 Andrea Pappacoda <andrea@pappacoda.it>
+.\" SPDX-License-Identifier: ISC
+.Dd 2022-08-30
+.Dt ZARCHIVE 1
+.Os
+.
+.Sh NAME
+.Nm zarchive
+.Nd create and read zstd-compressed file archives
+.
+.Sh SYNOPSIS
+.Nm
+.Ar input_path
+.Op Ar output_path
+.
+.Sh DESCRIPTION
+.Nm
+allows you to create and read file archives in the ZArchive format (.zar).
+.Pp
+ZArchive is yet another file archive format. Think of zip, tar, 7z, etc. but
+with the requirement of allowing random-access reads and supporting compression.
+.Sh EXIT STATUS
+.Ex -std
+.
+.Sh EXAMPLES
+.Bd -literal
+$ zarchive src
+Outputting to: src.zar
+Adding main.cpp
+Adding zarchivereader.cpp
+Adding zarchivewriter.cpp
+Adding sha_256.c
+Adding sha_256.h
+.Ed
+.
+.Sh SEE ALSO
+.Xr zstd 1
+.
+.Sh AUTHORS
+.An -nosplit
+The ZArchive format, library and tool were written by
+.An Exzap .
+The
+.Nm
+manual page was written by
+.An Andrea Pappacoda Aq Mt andrea@pappacoda.it .


### PR DESCRIPTION
This patch adds a small `zarchive(1)` manual page, mostly useful for Linux and BSD users. It's also possible to convert it into other formats, like HTML.

Here's how it looks on a terminal:

![image](https://user-images.githubusercontent.com/34214253/187550734-09e8de57-b11e-4020-a4d9-30b972ad2adb.png)
