### PR TITLE
fix(main.cpp): mark unused parameter as such

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -118,7 +118,7 @@ struct PackContext
 	bool hasError{false};
 };
 
-void _pack_NewOutputFile(const int32_t partIndex, void* ctx)
+void _pack_NewOutputFile(const int32_t /*partIndex*/, void* ctx)
 {
 	PackContext* packContext = (PackContext*)ctx;
 	packContext->currentOutputFile = std::ofstream(packContext->outputFilePath, std::ios::binary);


### PR DESCRIPTION
Fixes a compiler warning, `-Wunused-parameter`